### PR TITLE
Fix toolbar under shadow DOM

### DIFF
--- a/d2l-pdf-viewer-toolbar-button.html
+++ b/d2l-pdf-viewer-toolbar-button.html
@@ -6,7 +6,7 @@
 <dom-module id="d2l-pdf-viewer-toolbar-button">
 	<template strip-whitespace>
 		<style>
-			button {
+			:host {
 				cursor: pointer;
 				border: none;
 				border-radius: 6px;
@@ -17,20 +17,14 @@
 				padding: 0;
 			}
 
-			button[aria-disabled="true"],
-			button:disabled {
+			:host([disabled]) {
 				cursor: default;
 				opacity: .5;
 			}
 
-			button:focus,
-			button:hover:not([aria-disabled="true"]):not(:disabled) {
+			:host(:focus),
+			:host(:hover:not([disabled])) {
 				background-color: var(--d2l-color-celestine);
-			}
-
-			/* Firefox includes a hidden border which messes up button dimensions */
-			button::-moz-focus-inner {
-				border: 0;
 			}
 
 			d2l-icon {
@@ -38,30 +32,31 @@
 				padding: 6px;
 			}
 		</style>
-		<button
-			aria-disabled$="[[_getAriaDisabled(ariaDisabled)]]"
-			aria-label$="[[ariaLabel]]"
-			aria-pressed$="[[_getAriaPressed(toggle, pressed)]]"
-			disabled$="[[disabled]]"
-			title$=[[title]]>
-			<d2l-icon icon="[[icon]]"></d2l-icon>
-		</button>
+		<d2l-icon icon="[[icon]]"></d2l-icon>
 	</template>
 	<script>
 		Polymer({
 			is: 'd2l-pdf-viewer-toolbar-button',
 
+			hostAttributes: {
+				role: 'button',
+				tabIndex: -1
+			},
+
+			listeners: {
+				'focusin': '_onInteraction',
+				'focusout': '_onInteraction'
+			},
+
 			properties: {
-				ariaDisabled: {
-					type: Boolean,
-					value: false
-				},
 				ariaLabel: {
-					type: String
+					type: String,
+					reflectToAttribute: true
 				},
 				disabled: {
 					type: Boolean,
-					value: false
+					value: false,
+					reflectToAttribute: true
 				},
 				icon: {
 					type: String
@@ -74,29 +69,28 @@
 					type: Boolean,
 					value: false
 				},
-				active: {
-					type: Boolean,
-					value: false
-				},
 				title: {
 					type: String
 				}
 			},
 
-			ready: function() {
-				this.$$('button').tabIndex = this.active ? 0 : -1;
+			observers: [
+				'_setAriaPressed(toggle, pressed)'
+			],
+
+			_onInteraction: function() {
+				this.dispatchEvent(new CustomEvent('d2l-pdf-viewer-button-interaction', {
+					bubbles: true,
+					composed: true
+				}));
 			},
 
-			_getAriaDisabled: function(ariaDisabled) {
-				return ariaDisabled ? 'true' : undefined;
-			},
-
-			_getAriaPressed: function(toggle, pressed) {
+			_setAriaPressed: function(toggle, pressed) {
 				if (!toggle) {
-					return false; // Don't apply attribute at all - not toggle button
+					this.removeAttribute('aria-pressed');
+				} else {
+					this.setAttribute('aria-pressed', pressed ? 'true' : 'false');
 				}
-
-				return pressed ? 'true' : 'false'; // Indicate state of toggle button
 			}
 		});
 	</script>

--- a/d2l-pdf-viewer-toolbar.html
+++ b/d2l-pdf-viewer-toolbar.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-arrowkeys-behavior.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="../d2l-fastdom-import/fastdom.html">
 <link rel="import" href="./d2l-pdf-viewer-toolbar-button.html">
 <link rel="import" href="./localize-behavior.html">
 
@@ -78,31 +79,36 @@
 				</div>
 				<div class="control-container" role="group">
 					<d2l-pdf-viewer-toolbar-button
-						active
 						id="zoomOutButton"
 						title="[[localize('zoomOutTitle')]]"
 						icon="d2l-tier1:zoom-out"
 						on-tap="_onZoomOutButtonTapped"
+						on-keydown="_onToolbarButtonKeyDown"
 						aria-label="[[localize('zoomOutLabel')]]"
-						aria-disabled="[[_zoomOutButtonDisabled(pageScale, minPageScale)]]">
+						disabled="[[_zoomOutButtonDisabled(pageScale, minPageScale)]]"
+						tabindex="0">
 					</d2l-pdf-viewer-toolbar-button>
 					<d2l-pdf-viewer-toolbar-button
 						id="zoomInButton"
 						on-tap="_onZoomInButtonTapped"
+						on-keydown="_onToolbarButtonKeyDown"
 						title="[[localize('zoomInTitle')]]"
 						icon="d2l-tier1:zoom-in"
 						aria-label="[[localize('zoomInLabel')]]"
-						aria-disabled="[[_zoomInButtonDisabled(pageScale, maxPageScale)]]">
+						disabled="[[_zoomInButtonDisabled(pageScale, maxPageScale)]]"
+						tabindex="-1">
 					</d2l-pdf-viewer-toolbar-button>
 					<d2l-pdf-viewer-toolbar-button
 						toggle
 						id="fullscreenButton"
 						on-tap="_onToggleFullscreenButtonTapped"
+						on-keydown="_onToolbarButtonKeyDown"
 						title="[[localize('presentationModeTitle')]]"
 						icon="[[_getFullscreenIcon(isFullscreen)]]"
 						aria-label="[[localize('presentationModeLabel')]]"
 						pressed="[[isFullscreen]]"
-						disabled="[[!fullscreenAvailable]]">
+						disabled="[[!fullscreenAvailable]]"
+						tabindex="-1">
 					</d2l-pdf-viewer-toolbar-button>
 				</div>
 			</div>
@@ -113,10 +119,6 @@
 			is: 'd2l-pdf-viewer-toolbar',
 			hostAttributes: {
 				role: 'toolbar'
-			},
-			listeners: {
-				'focusin': '_onFocusIn',
-				'focusout': '_onFocusOut'
 			},
 			properties: {
 				fullscreenAvailable: {
@@ -187,49 +189,27 @@
 					: 'd2l-tier1:fullscreen';
 			},
 			_initRovingTabIndex: function() {
-				const toolbarControls = this.getElementsByTagName('d2l-pdf-viewer-toolbar-button');
-				const toolbarButtons = Array.prototype.slice.call(toolbarControls)
-					.map(control => {
-						return control.getElementsByTagName('button')[0];
-					});
+				const toolbarControls = Polymer.dom(this.root).querySelectorAll('d2l-pdf-viewer-toolbar-button');
+				const toolbarButtons = Array.prototype.slice.call(toolbarControls);
 
 				this.arrowKeyFocusablesContainer = this.$$('.control-container');
 
 				this.arrowKeyFocusablesProvider = () => {
-					const activeButtons = toolbarButtons.filter(button => !button.disabled);
+					return new Promise((resolve) => {
+						fastdom.measure(() => {
+							const activeButtons = toolbarButtons.filter(button => !button.disabled);
 
-					return Promise.resolve(activeButtons);
+							resolve(activeButtons);
+						});
+					});
 				};
 			},
-			_onFocusIn: function(e) {
-				if (!e.target) {
-					return;
-				}
-
-				var targetParent = e.target.parentElement;
-
-				if (targetParent.tagName.toLowerCase() === 'd2l-pdf-viewer-toolbar-button') {
-					e.target.tabIndex = 0;
-				}
-			},
-			_onFocusOut: function(e) {
-				/* Make not-tabbable if we know we're moving to another button */
-				if (!e.target || !e.relatedTarget) {
-					return;
-				}
-
-				var targetParent = e.target.parentElement;
-
-				if (targetParent.tagName.toLowerCase() === 'd2l-pdf-viewer-toolbar-button') {
-					var parent = e.relatedTarget.parentElement;
-
-					if (!e.relatedTarget.tagName.toLowerCase() === 'd2l-pdf-viewer-toolbar-button') {
-						return;
-					}
-
-					if (D2L.Dom.isComposedAncestor(this, parent)) {
-						e.target.tabIndex = -1;
-					}
+			_onToolbarButtonKeyDown: function(e) {
+				switch (e.key) {
+					case 'Enter':
+					case 'Space':
+						e.composedPath()[0].click();
+						break;
 				}
 			}
 		});

--- a/d2l-pdf-viewer.html
+++ b/d2l-pdf-viewer.html
@@ -538,7 +538,8 @@
 				'touchend': '_onInteraction',
 				'touchmove': '_onInteraction',
 				'focusin': '_onInteraction',
-				'focusout': '_onFocusOut'
+				'focusout': '_onFocusOut',
+				'd2l-pdf-viewer-button-interaction': '_onInteraction'
 			},
 			observers: [
 				'_srcChanged(isAttached, src)'

--- a/test/d2l-pdf-viewer-toolbar.html
+++ b/test/d2l-pdf-viewer-toolbar.html
@@ -58,11 +58,9 @@
 					});
 
 					it('should render all elements correctly', function() {
-						for (const disabledType of ['disabled', 'ariaDisabled']) {
-							expect(toolbar.$.zoomOutButton[disabledType]).to.be.false;
-							expect(toolbar.$.zoomInButton[disabledType]).to.be.false;
-							expect(toolbar.$.fullscreenButton[disabledType]).to.be.false;
-						}
+						expect(toolbar.$.zoomOutButton.disabled).to.be.false;
+						expect(toolbar.$.zoomInButton.disabled).to.be.false;
+						expect(toolbar.$.fullscreenButton.disabled).to.be.false;
 
 						expect(toolbar.$.pageNumber.textContent.trim()).to.equal('Page 4 / 10');
 					});
@@ -70,7 +68,7 @@
 					it('should disable the "zoom in" button when pageScale >= maxPageScale', function(done) {
 						toolbar.pageScale = toolbar.maxPageScale;
 						setTimeout(function() {
-							expect(toolbar.$.zoomInButton.ariaDisabled).to.be.true;
+							expect(toolbar.$.zoomInButton.disabled).to.be.true;
 							done();
 						});
 					});
@@ -78,7 +76,7 @@
 					it('should disable the "zoom out" button when pageScale <= minPageScale', function(done) {
 						toolbar.pageScale = toolbar.minPageScale;
 						setTimeout(function() {
-							expect(toolbar.$.zoomOutButton.ariaDisabled).to.be.true;
+							expect(toolbar.$.zoomOutButton.disabled).to.be.true;
 							done();
 						});
 					});


### PR DESCRIPTION
Get toolbar working in both Polymer 1/2 shadow DOM prior to Polymer 3 conversion. This loses the roving tabindex for now (in that after leaving and re-entering the toolbar, the first toolbar button always gains focus, rather than last-focused), but this keeps things simpler - given that there's only a few buttons and accessibility is otherwise good, shouldn't be an issue (will look at adding that to `d2l-polymer-behaviors-ui`)

Also noticed that in the Firefox/mainline demo, tab focus essentially becomes "trapped" in the `d2l-pdf-viewer`, but this actually seems to be due to `demo-snippet` or similar - removing the `d2l-pdf-viewer` still results in odd behavior, and pulling `d2l-pdf-viewer` outside of it with other tabbable elements works fine, so don't think it's indicative of an actual issue.