### PR TITLE
Add support for loading PDF.js using script loader/from CDN

### DIFF
--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -591,7 +591,7 @@ Polymer({
 						detail: e
 					},
 				))) {
-					console.error(e);
+					console.error(e); //eslint-disable-line
 				}
 			});
 	},

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -1,4 +1,4 @@
-/* global pdfjsViewer pdfjsLib */
+/* global pdfjsViewer, pdfjsLib */
 
 import '@polymer/polymer/polymer-legacy.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -578,7 +578,9 @@ Polymer({
 		}
 
 		this._initializeTask = initializeTask
-			.then(this._librariesLoaded.bind(this))
+			.then(libraries => {
+				return this._onLibrariesLoaded(libraries);
+			})
 			.catch(e => {
 				this.$.progressBar.hidden = true;
 
@@ -626,7 +628,7 @@ Polymer({
 			.then(() => this._loadScript(`${basePath}/web/pdf_viewer.js`))
 			.then(() => {
 				return {
-					pdfjsLib: pdfjsLib,
+					pdfjsLib,
 					LinkTarget: pdfjsLib.LinkTarget,
 					PDFLinkService: pdfjsViewer.PDFLinkService,
 					PDFViewer: pdfjsViewer.PDFViewer,
@@ -644,7 +646,7 @@ Polymer({
 			scriptTag.src = src;
 		});
 	},
-	_librariesLoaded: function({
+	_onLibrariesLoaded: function({
 		pdfjsLib,
 		LinkTarget,
 		PDFViewer,

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -496,6 +496,9 @@ Polymer({
 		pdfJsWorkerSrc: {
 			type: String
 		},
+		pdfJsRemotePath: {
+			type: String
+		},
 		src: {
 			type: String
 		},
@@ -549,11 +552,13 @@ Polymer({
 	ready: function() {
 		this._boundListeners = false;
 		this._addedEventListeners = false;
+
+		const importPath = this.pdfJsRemotePath || 'pdfjs-dist-modules';
 		// Import pdfjs separately to allow better code splitting
 		this._initializeTask = Promise.all([
-			import('pdfjs-dist-modules/pdf.js'),
-			import('pdfjs-dist-modules/pdf_link_service.js'),
-			import('pdfjs-dist-modules/pdf_viewer.js')
+			import(`${importPath}/pdf.js`),
+			import(`${importPath}/pdf_link_service.js`),
+			import(`${importPath}/pdf_viewer.js`)
 		])
 			.then(([pdfImport, pdfLinkServiceImport, pdfViewerImport]) => {
 				const pdf = pdfImport.default;
@@ -566,8 +571,11 @@ Polymer({
 				// under Shady DOM
 				this.scopeSubtree(this.$.viewerContainer, true);
 
-				pdf.GlobalWorkerOptions.workerSrc =
-					this.pdfJsWorkerSrc || import.meta.url + '/../node_modules/pdfjs-dist-modules/pdf.worker.min.js';
+				const workerSrc = this.pdfJsRemotePath
+					? `${this.pdfJsRemotePath}/pdf.worker.min.js`
+					: this.pdfJsWorkerSrc || `${import.meta.url}/../node_modules/pdfjs-dist-modules/pdf.worker.min.js`;
+
+				pdf.GlobalWorkerOptions.workerSrc = workerSrc;
 
 				// (Optionally) enable hyperlinks within PDF files.
 				this._pdfLinkService = new PDFLinkService({

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -576,7 +576,7 @@ Polymer({
 			scriptTag.onerror = reject;
 			scriptTag.src = src;
 		}).catch(() => {
-			const progressBar = bundledthis.$.progressBar;
+			const progressBar = this.$.progressBar;
 			progressBar.hidden = true;
 
 			this.dispatchEvent(new CustomEvent(

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -588,7 +588,8 @@ Polymer({
 					'd2l-pdf-viewer-load-failed', {
 						bubbles: true,
 						composed: true,
-						detail: e
+						detail: e,
+						cancelable: true
 					},
 				))) {
 					console.error(e); //eslint-disable-line

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -598,8 +598,7 @@ Polymer({
 			scriptTag.onerror = reject;
 			scriptTag.src = src;
 		}).catch(() => {
-			const progressBar = this.$.progressBar;
-			progressBar.hidden = true;
+			this.$.progressBar.hidden = true;
 
 			this.dispatchEvent(new CustomEvent(
 				'd2l-pdf-viewer-load-failed',

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -576,7 +576,7 @@ Polymer({
 			scriptTag.onerror = reject;
 			scriptTag.src = src;
 		}).catch(() => {
-			const progressBar = this.$.progressBar;
+			const progressBar = bundledthis.$.progressBar;
 			progressBar.hidden = true;
 
 			this.dispatchEvent(new CustomEvent(
@@ -590,9 +590,9 @@ Polymer({
 		// under Shady DOM
 		this.scopeSubtree(this.$.viewerContainer, true);
 
-		pdfjsLib.GlobalWorkerOptions.workerSrc =
-			this.pdfJsWorkerSrc ||
-			'https://cdn.jsdelivr.net/npm/pdfjs-dist@2.0.943/build/pdf.worker.min.js';
+		pdfjsLib.GlobalWorkerOptions.workerSrc = this.bundled
+			? this.pdfJsWorkerSrc
+			: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@2.0.943/build/pdf.worker.min.js';
 
 		// (Optionally) enable hyperlinks within PDF files.
 		this._pdfLinkService = new pdfjsViewer.PDFLinkService({

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -487,7 +487,7 @@ Polymer({
 		'aria-describedby': 'pdfName'
 	},
 	properties: {
-		loaderType: {
+		loader: {
 			type: String,
 			value: 'import'
 		},
@@ -565,8 +565,8 @@ Polymer({
 
 		this._workerSrc = this.pdfJsWorkerSrc;
 
-		// Currently the loaderType implies useCdn, but ideally isn't in the future
-		switch (this.loaderType) {
+		// Currently the loader implies useCdn, but ideally isn't in the future
+		switch (this.loader) {
 			case 'import':
 				initializeTask = this._loadDynamicImports();
 				break;
@@ -574,25 +574,26 @@ Polymer({
 				initializeTask = this._loadScripts();
 				break;
 			default:
-				throw new Error(`unknown loaderType: ${this.loaderType}`);
+				initializeTask = Promise.reject(`unknown loaderType: ${this.loader}`);
 		}
 
 		this._initializeTask = initializeTask
 			.then(this._librariesLoaded.bind(this))
-			.catch(() => {
+			.catch(e => {
 				this.$.progressBar.hidden = true;
 
 				this.dispatchEvent(new CustomEvent(
 					'd2l-pdf-viewer-load-failed', {
 						bubbles: true,
 						composed: true,
+						detail: e
 					},
 				));
 			});
 	},
 	_loadDynamicImports: function() {
 		if (this.useCdn || this.pdfjsBasePath) {
-			throw new Error('loaderType `import` does not have CDN/base path support');
+			return Promise.reject('loaderType `import` does not have CDN/base path support');
 		}
 
 		if (!this._workerSrc) {
@@ -614,7 +615,7 @@ Polymer({
 	},
 	_loadScripts: function() {
 		const basePath = this.useCdn
-			? 'https://cdn.jsdelivr.net/npm/pdfjs-dist@2.0.943'
+			? 'https://s.brightspace.com/lib/pdf.js/2.0.943'
 			: this.pdfjsBasePath || `${import.meta.url}/../node_modules/pdfjs-dist`;
 
 		if (!this._workerSrc) {

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -574,7 +574,7 @@ Polymer({
 				initializeTask = this._loadScripts();
 				break;
 			default:
-				initializeTask = Promise.reject(`unknown loaderType: ${this.loader}`);
+				initializeTask = Promise.reject(`unknown loader: ${this.loader}`);
 		}
 
 		this._initializeTask = initializeTask
@@ -584,18 +584,20 @@ Polymer({
 			.catch(e => {
 				this.$.progressBar.hidden = true;
 
-				this.dispatchEvent(new CustomEvent(
+				if (this.dispatchEvent(new CustomEvent(
 					'd2l-pdf-viewer-load-failed', {
 						bubbles: true,
 						composed: true,
 						detail: e
 					},
-				));
+				))) {
+					console.error(e);
+				}
 			});
 	},
 	_loadDynamicImports: function() {
 		if (this.useCdn || this.pdfjsBasePath) {
-			return Promise.reject('loaderType `import` does not have CDN/base path support');
+			return Promise.reject('loader `import` does not have CDN/base path support');
 		}
 
 		if (!this._workerSrc) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -77,7 +77,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 					</style>
 					<h3>Script loader from CDN</h3>
 					<d2l-pdf-viewer
-						loader-type="script"
+						loader="script"
 						use-cdn
 						src="/demo/compressed.tracemonkey-pldi-09.pdf"
 					></d2l-pdf-viewer>

--- a/demo/index.html
+++ b/demo/index.html
@@ -61,10 +61,26 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							width: 100%;
 						}
 					</style>
+					<h3>ECMAScript Module</h3>
 					<d2l-pdf-viewer
 						src="/demo/compressed.tracemonkey-pldi-09.pdf"
-					>
-					</d2l-pdf-viewer>
+					></d2l-pdf-viewer>
+				</template>
+			</demo-snippet>
+			<demo-snippet>
+				<template strip-whitespace="">
+					<style>
+						d2l-pdf-viewer {
+							height: 500px;
+							width: 100%;
+						}
+					</style>
+					<h3>Script loader from CDN</h3>
+					<d2l-pdf-viewer
+						loader-type="script"
+						use-cdn
+						src="/demo/compressed.tracemonkey-pldi-09.pdf"
+					></d2l-pdf-viewer>
 				</template>
 			</demo-snippet>
 		</div>`;

--- a/demo/index.html
+++ b/demo/index.html
@@ -61,7 +61,10 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							width: 100%;
 						}
 					</style>
-					<d2l-pdf-viewer src="/demo/compressed.tracemonkey-pldi-09.pdf"></d2l-pdf-viewer>
+					<d2l-pdf-viewer
+						src="/demo/compressed.tracemonkey-pldi-09.pdf"
+					>
+					</d2l-pdf-viewer>
 				</template>
 			</demo-snippet>
 		</div>`;

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "eslint": "^4.19.1",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.5",
+    "pdfjs-dist": "^2.2.228",
+    "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943",
     "polymer-cli": "^1.9.6",
-    "wct-browser-legacy": "^1.0.1",
-    "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943"
+    "wct-browser-legacy": "^1.0.1"
   },
   "version": "2.0.0",
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.5",
     "polymer-cli": "^1.9.6",
-    "wct-browser-legacy": "^1.0.1"
+    "wct-browser-legacy": "^1.0.1",
+    "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943"
   },
   "version": "2.0.0",
   "resolutions": {
@@ -43,7 +44,9 @@
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fastdom": "^1.0.8",
-    "fullscreen-api": "Brightspace/fullscreen-api#semver:^3",
-    "pdfjs-dist-modules": "github:Brightspace/pdfjs-dist-modules#semver:2.0.943"
+    "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"
+  },
+  "peerDependencies": {
+    "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943"
   }
 }


### PR DESCRIPTION
Some build tools, like `polymer build`, may fail when analyzing large dependencies like `pdfjs-dist{-modules}`, so allow for loading via CDN.