### PR TITLE
Make pdfjs-dist-modules optional dep rather than peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,45 +5,32 @@
 
 ## Installation
 
-`d2l-pdf-viewer` can be installed from [Bower][bower-url]:
+`d2l-pdf-viewer` can be installed using npm:
 ```shell
-bower install d2l-pdf-viewer
+npm i --save Brightspace/d2l-pdf-viewer
 ```
 
 ## Usage
 
-Include the [webcomponents.js](http://webcomponents.org/polyfills/) polyfill (for browsers who don't natively support web components), then import `d2l-pdf-viewer.html`:
+Import `d2l-pdf-viewer.js` for side-effects:
+
+```javascript
+import 'd2l-pdf-viewer/d2l-pdf-viewer.js';
+```
 
 ```html
-<head>
-	<script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-	<link rel="import" href="bower_components/d2l-pdf-viewer/d2l-pdf-viewer.html">
-</head>
+<!-- Basic example of adding a PDF viewer that uses the Brightspace CDN for dependencies -->
+<d2l-pdf-viewer
+	src="path/to/my.pdf"
+	loader="script"
+	use-cdn
+></d2l-pdf-viewer>
 ```
 
-<!---
+See [the main source file (d2l-pdf-viewer.js)](./d2l-pdf-viewer.js) for documentation of the full public API.
+
 ```
-<custom-element-demo>
-  <template>
-    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../d2l-typography/d2l-typography.html">
-    <link rel="import" href="d2l-pdf-viewer.html">
-    <custom-style include="d2l-typography">
-      <style is="custom-style" include="d2l-typography"></style>
-    </custom-style>
-    <style>
-      html {
-        font-size: 20px;
-        font-family: 'Lato', 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;
-      }
-    </style>
-    <next-code-block></next-code-block>
-  </template>
-</custom-element-demo>
-```
--->
-```html
-<d2l-pdf-viewer>My element</d2l-pdf-viewer>
+Note: This component optionally supports loading PDF.js using ES6 modules, which use dynamic imports. To support this in Webpack builds, an explicit opt-out of dynamic module parsing is performed within this component. For more details, see https://webpack.js.org/api/module-methods/#magic-comments
 ```
 
 ## Developing, Testing and Contributing
@@ -79,5 +66,4 @@ To lint AND run local unit tests:
 ```shell
 npm test
 ```
-
 

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -606,9 +606,9 @@ Polymer({
 		}
 
 		return Promise.all([
-			import('pdfjs-dist-modules/pdf.js'),
-			import('pdfjs-dist-modules/pdf_link_service.js'),
-			import('pdfjs-dist-modules/pdf_viewer.js')
+			import(/* webpackIgnore: true */ 'pdfjs-dist-modules/pdf.js'),
+			import(/* webpackIgnore: true */ 'pdfjs-dist-modules/pdf_link_service.js'),
+			import(/* webpackIgnore: true */ 'pdfjs-dist-modules/pdf_viewer.js')
 		]).then(([pdfImport, pdfLinkServiceImport, pdfViewerImport]) => {
 			return {
 				pdfjsLib: pdfImport.default,

--- a/d2l-pdf-viewer.js
+++ b/d2l-pdf-viewer.js
@@ -487,25 +487,55 @@ Polymer({
 		'aria-describedby': 'pdfName'
 	},
 	properties: {
+		/**
+		* The method used to load PDF.js.
+		* Options:
+		* 	- import: Uses ES6 dynamic imports to load an ES6 module version
+		*		Note: Consumer must install https://github.com/Brightspace/pdfjs-dist-modules
+		* 	- script: Uses asyncronous scripts to load a standard PDF.js distribution
+		*/
 		loader: {
 			type: String,
 			value: 'import'
 		},
+		/*
+		* The minimum scale that can be set when zooming the page out.
+		*/
 		minPageScale: {
 			type: Number,
 			value: 0.1
 		},
+		/*
+		* The maximum scale that can be set when zooming the page in.
+		*/
 		maxPageScale: {
 			type: Number,
 			value: 5
 		},
+		/*
+		* The path base to use when loading PDF.js source files (eg, a path to a CDN version,
+		* minus file names.)
+		* Note: This is currently only valid when `loader` type is `source`.
+		*/
 		pdfjsBasePath: String,
+		/*
+		* Allows the worker source location to be supplied explicitly. Will be inferred if
+		* unset, and should only be set in specific cases (eg, worker can't be inferred
+		* correctly due to consumer-specific bundling).
+		*/
 		pdfJsWorkerSrc: {
 			type: String
 		},
+		/*
+		* The URI of the PDF to display.
+		*/
 		src: {
 			type: String
 		},
+		/*
+		* A convenience option to load PDF.js source files from the Brightspace CDN.
+		* Currently only valid when `loader` type is `script`.
+		*/
 		useCdn: {
 			type: Boolean,
 			value: false

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fastdom": "^1.0.8",
     "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,21 @@
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
+  "version": "2.3.0",
+  "main": "d2l-pdf-viewer.js",
+  "dependencies": {
+    "@polymer/polymer": "^3.0.0",
+    "d2l-colors": "BrightspaceUI/colors#semver:^4",
+    "d2l-icons": "BrightspaceUI/icons#semver:^6",
+    "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
+    "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+    "d2l-typography": "BrightspaceUI/typography#semver:^7",
+    "fastdom": "^1.0.8",
+    "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"
+  },
+  "optionalDependencies": {
+    "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943"
+  },
   "devDependencies": {
     "@polymer/iron-demo-helpers": "^3.0.0",
     "@polymer/iron-test-helpers": "^3.0.0",
@@ -29,25 +44,10 @@
     "polymer-cli": "^1.9.6",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "2.0.0",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",
     "supports-color": "3.1.2",
     "type-detect": "1.0.0"
-  },
-  "main": "d2l-pdf-viewer.js",
-  "dependencies": {
-    "@polymer/polymer": "^3.0.0",
-    "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
-    "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
-    "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "fastdom": "^1.0.8",
-    "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"
-  },
-  "optionalDependencies": {
-    "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943"
   }
 }


### PR DESCRIPTION
Peer dependencies are still required, whereas optional are, well, optional.

Also need to opt-out of Webpack dynamic import parsing/code splitting for the dynamic import of `pdfjs-dist-modules`, else Webpack will fail if `pdfjs-dist-modules` isn't installed. All uses now (so far) will use the CDN, but this would still be a nice option for some cases. (I'm not aware of a way to define it in the consumer rather than have to cover bundler-specific magic comments here, but, seems necessary)