### PR TITLE
Move pdfjs-dist-modules back to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fastdom": "^1.0.8",
     "fullscreen-api": "Brightspace/fullscreen-api#semver:^3"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "pdfjs-dist-modules": "Brightspace/pdfjs-dist-modules#semver:2.0.943"
   },
   "devDependencies": {


### PR DESCRIPTION
Some consumers can't be expected to exercise the option to not install optional dependencies, and this is actually installed by default otherwise (ie. by default, stronger than `peerDependencies`), so revert to `peerDependency` (ie. by default, do not install), and the consumer should consider warnings related to this informational only.